### PR TITLE
Fix uninitialized overallStatus, which breaks webui

### DIFF
--- a/library/Vspheredb/Sync/SyncManagedObjectReferences.php
+++ b/library/Vspheredb/Sync/SyncManagedObjectReferences.php
@@ -48,6 +48,7 @@ class SyncManagedObjectReferences
             $uuid = $vCenter->makeBinaryGlobalUuid($moRef);
             $fetched[$uuid] = $name;
             $nameUuids[$moRef] = $uuid;
+            $obj->overallStatus = isset($obj->overallStatus) ? $obj->overallStatus : 'gray';  //** Handle cases where Vcenter gives us a blank overallStatus.**/
             if (array_key_exists($uuid, $objects)) {
                 $object = $objects[$uuid];
                 $object->set('moref', $moRef);


### PR DESCRIPTION
As currently written, if overallStatus is not populated, it breaks the entire moRef sync routine & leaves the object table unpopulated.

By forcing the status to 'grey' if it is null, this is corrected.